### PR TITLE
Made bash commands able to be copy+pasted

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ You'll need a postgres instance running on localhost, with a
 going...
 
 ```bash
-$ git clone https://github.com/steveklabnik/rustmvc
-$ cd rustmvc
-$ cargo build
-$ ./target/create_databases # you only need this the first time
-$ cargo run
-$ firefox http://localhost:6767/ # in a different shell, of course
+git clone https://github.com/steveklabnik/rustmvc
+cd rustmvc
+cargo build
+./target/create_databases # you only need this the first time
+cargo run
+firefox http://localhost:6767/ # in a different shell, of course
 ```


### PR DESCRIPTION
What do you think? :smile: I'm sure it's not to everyone's taste, but I think users like to be able to copy and paste code blocks but the `$` on each line makes this impossible (for me).
