### PR TITLE
Working get_todos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,10 @@
 name = "rustmvc"
 version = "0.0.1"
 dependencies = [
- "nickel 0.1.0 (git+https://github.com/iterion/nickel.rs.git)",
+ "nickel 0.1.0 (git+https://github.com/nickel-org/nickel.rs.git)",
  "postgres 0.0.0 (git+https://github.com/sfackler/rust-postgres.git)",
  "r2d2_postgres 0.0.0 (git+https://github.com/sfackler/r2d2-postgres.git)",
+ "time 0.0.2 (git+https://github.com/rust-lang/time.git)",
 ]
 
 [[package]]
@@ -14,8 +15,8 @@ source = "git+https://github.com/nickel-org/anymap.git#c29e78c5634f9e6741287e9cf
 
 [[package]]
 name = "encoding"
-version = "0.2.0"
-source = "git+https://github.com/lifthrasiir/rust-encoding#d67c864d8dfeb16a00656e9472133b0e2206781f"
+version = "0.2.1"
+source = "git+https://github.com/lifthrasiir/rust-encoding#6a5a95950572590485cbbf64509036b252339205"
 dependencies = [
  "encoding-index-japanese 1.0.20140915 (git+https://github.com/lifthrasiir/rust-encoding)",
  "encoding-index-korean 1.0.20140915 (git+https://github.com/lifthrasiir/rust-encoding)",
@@ -27,7 +28,7 @@ dependencies = [
 [[package]]
 name = "encoding-index-japanese"
 version = "1.0.20140915"
-source = "git+https://github.com/lifthrasiir/rust-encoding#d67c864d8dfeb16a00656e9472133b0e2206781f"
+source = "git+https://github.com/lifthrasiir/rust-encoding#6a5a95950572590485cbbf64509036b252339205"
 dependencies = [
  "encoding_index_tests 0.1.0 (git+https://github.com/lifthrasiir/rust-encoding)",
 ]
@@ -35,7 +36,7 @@ dependencies = [
 [[package]]
 name = "encoding-index-korean"
 version = "1.0.20140915"
-source = "git+https://github.com/lifthrasiir/rust-encoding#d67c864d8dfeb16a00656e9472133b0e2206781f"
+source = "git+https://github.com/lifthrasiir/rust-encoding#6a5a95950572590485cbbf64509036b252339205"
 dependencies = [
  "encoding_index_tests 0.1.0 (git+https://github.com/lifthrasiir/rust-encoding)",
 ]
@@ -43,7 +44,7 @@ dependencies = [
 [[package]]
 name = "encoding-index-simpchinese"
 version = "1.0.20140915"
-source = "git+https://github.com/lifthrasiir/rust-encoding#d67c864d8dfeb16a00656e9472133b0e2206781f"
+source = "git+https://github.com/lifthrasiir/rust-encoding#6a5a95950572590485cbbf64509036b252339205"
 dependencies = [
  "encoding_index_tests 0.1.0 (git+https://github.com/lifthrasiir/rust-encoding)",
 ]
@@ -51,7 +52,7 @@ dependencies = [
 [[package]]
 name = "encoding-index-singlebyte"
 version = "1.0.20140915"
-source = "git+https://github.com/lifthrasiir/rust-encoding#d67c864d8dfeb16a00656e9472133b0e2206781f"
+source = "git+https://github.com/lifthrasiir/rust-encoding#6a5a95950572590485cbbf64509036b252339205"
 dependencies = [
  "encoding_index_tests 0.1.0 (git+https://github.com/lifthrasiir/rust-encoding)",
 ]
@@ -59,7 +60,7 @@ dependencies = [
 [[package]]
 name = "encoding-index-tradchinese"
 version = "1.0.20140915"
-source = "git+https://github.com/lifthrasiir/rust-encoding#d67c864d8dfeb16a00656e9472133b0e2206781f"
+source = "git+https://github.com/lifthrasiir/rust-encoding#6a5a95950572590485cbbf64509036b252339205"
 dependencies = [
  "encoding_index_tests 0.1.0 (git+https://github.com/lifthrasiir/rust-encoding)",
 ]
@@ -67,7 +68,7 @@ dependencies = [
 [[package]]
 name = "encoding_index_tests"
 version = "0.1.0"
-source = "git+https://github.com/lifthrasiir/rust-encoding#d67c864d8dfeb16a00656e9472133b0e2206781f"
+source = "git+https://github.com/lifthrasiir/rust-encoding#6a5a95950572590485cbbf64509036b252339205"
 
 [[package]]
 name = "gcc"
@@ -82,10 +83,10 @@ source = "git+https://github.com/nickel-org/groupable-rs#74c9e38ede02008fc04c47a
 [[package]]
 name = "http"
 version = "0.1.0-pre"
-source = "git+https://github.com/iterion/rust-http.git#a76c947ead4f98bc782610caf2d4919e09076949"
+source = "git+https://github.com/nickel-org/rust-http.git#5b4786ca9b74434d91aab0e4fde8ed1a3aec77bd"
 dependencies = [
  "openssl 0.0.1 (git+https://github.com/sfackler/rust-openssl)",
- "time 0.0.1 (git+https://github.com/rust-lang/time)",
+ "time 0.0.2 (git+https://github.com/rust-lang/time.git)",
  "url 0.1.0 (git+https://github.com/nickel-org/rust-url.git)",
 ]
 
@@ -100,25 +101,26 @@ dependencies = [
 [[package]]
 name = "nickel"
 version = "0.1.0"
-source = "git+https://github.com/iterion/nickel.rs.git#a80949b97c10f694b4d718cb543f5a4ef560255f"
+source = "git+https://github.com/nickel-org/nickel.rs.git#18d8f04bb7095ef202fba7ca3b9c3c7b3157554c"
 dependencies = [
  "anymap 0.9.0 (git+https://github.com/nickel-org/anymap.git)",
  "groupable 0.1.0 (git+https://github.com/nickel-org/groupable-rs)",
- "http 0.1.0-pre (git+https://github.com/iterion/rust-http.git)",
- "nickel_macros 0.0.1 (git+https://github.com/iterion/nickel.rs.git)",
+ "http 0.1.0-pre (git+https://github.com/nickel-org/rust-http.git)",
+ "nickel_macros 0.0.1 (git+https://github.com/nickel-org/nickel.rs.git)",
  "rust-mustache 0.3.0 (git+https://github.com/nickel-org/rust-mustache.git)",
+ "time 0.0.2 (git+https://github.com/rust-lang/time.git)",
  "url 0.1.0 (git+https://github.com/nickel-org/rust-url.git)",
 ]
 
 [[package]]
 name = "nickel_macros"
 version = "0.0.1"
-source = "git+https://github.com/iterion/nickel.rs.git#a80949b97c10f694b4d718cb543f5a4ef560255f"
+source = "git+https://github.com/nickel-org/nickel.rs.git#18d8f04bb7095ef202fba7ca3b9c3c7b3157554c"
 
 [[package]]
 name = "openssl"
 version = "0.0.1"
-source = "git+https://github.com/sfackler/rust-openssl#fa42ed9edcbd12e850e2eae95edb3e32da47f62c"
+source = "git+https://github.com/sfackler/rust-openssl#3e98880fe8cdeaccd3c08e423bc6ce7a211bae0a"
 dependencies = [
  "libressl-pnacl-sys 2.0.0 (git+https://github.com/DiamondLovesYou/libressl-pnacl-sys.git)",
  "openssl-sys 0.0.1 (git+https://github.com/sfackler/rust-openssl)",
@@ -127,7 +129,7 @@ dependencies = [
 [[package]]
 name = "openssl-sys"
 version = "0.0.1"
-source = "git+https://github.com/sfackler/rust-openssl#fa42ed9edcbd12e850e2eae95edb3e32da47f62c"
+source = "git+https://github.com/sfackler/rust-openssl#3e98880fe8cdeaccd3c08e423bc6ce7a211bae0a"
 dependencies = [
  "pkg-config 0.0.1 (git+https://github.com/alexcrichton/pkg-config-rs)",
 ]
@@ -135,7 +137,7 @@ dependencies = [
 [[package]]
 name = "phf"
 version = "0.0.0"
-source = "git+https://github.com/sfackler/rust-phf#88abf6c8b081439c8cb1458289790d0ee8f4d04a"
+source = "git+https://github.com/sfackler/rust-phf#aa3e2d0aedea4d55c2e4cea1bdf6e89418dc1206"
 dependencies = [
  "xxhash 0.0.1 (git+https://github.com/Jurily/rust-xxhash)",
 ]
@@ -143,8 +145,9 @@ dependencies = [
 [[package]]
 name = "phf_mac"
 version = "0.0.0"
-source = "git+https://github.com/sfackler/rust-phf#88abf6c8b081439c8cb1458289790d0ee8f4d04a"
+source = "git+https://github.com/sfackler/rust-phf#aa3e2d0aedea4d55c2e4cea1bdf6e89418dc1206"
 dependencies = [
+ "time 0.0.2 (git+https://github.com/rust-lang/time.git)",
  "xxhash 0.0.1 (git+https://github.com/Jurily/rust-xxhash)",
 ]
 
@@ -161,23 +164,24 @@ source = "git+https://github.com/DiamondLovesYou/cargo-pnacl-helper.git#5402d48d
 [[package]]
 name = "postgres"
 version = "0.0.0"
-source = "git+https://github.com/sfackler/rust-postgres.git#a0888e481a562275750e2fe9d55b186c220a8c68"
+source = "git+https://github.com/sfackler/rust-postgres.git#3a0f1897277d0e1f5568e733854649f1e7fd018d"
 dependencies = [
  "openssl 0.0.1 (git+https://github.com/sfackler/rust-openssl)",
  "phf 0.0.0 (git+https://github.com/sfackler/rust-phf)",
  "phf_mac 0.0.0 (git+https://github.com/sfackler/rust-phf)",
- "time 0.0.1 (git+https://github.com/rust-lang/time)",
+ "time 0.0.2 (git+https://github.com/rust-lang/time.git)",
+ "uuid 0.0.2 (git+https://github.com/rust-lang/uuid)",
 ]
 
 [[package]]
 name = "r2d2"
 version = "0.0.0"
-source = "git+https://github.com/sfackler/r2d2#d7c2835f9c8d33531683f8022fd0327dab2bed90"
+source = "git+https://github.com/sfackler/r2d2#8337055e2a5a2db9151ab62ea6d2e7e401d1c0d5"
 
 [[package]]
 name = "r2d2_postgres"
 version = "0.0.0"
-source = "git+https://github.com/sfackler/r2d2-postgres.git#2d5c9c55cec9402e25fe257daa13011d956534f5"
+source = "git+https://github.com/sfackler/r2d2-postgres.git#b624982db9068932f39b3a618ade1ea3dcc7d5ca"
 dependencies = [
  "postgres 0.0.0 (git+https://github.com/sfackler/rust-postgres.git)",
  "r2d2 0.0.0 (git+https://github.com/sfackler/r2d2)",
@@ -186,12 +190,12 @@ dependencies = [
 [[package]]
 name = "rust-mustache"
 version = "0.3.0"
-source = "git+https://github.com/nickel-org/rust-mustache.git#bf46d703791ba78ff10341f782534cf71a919db8"
+source = "git+https://github.com/nickel-org/rust-mustache.git#6f98a76ba46068f04c14b942a182e29eea24350e"
 
 [[package]]
 name = "time"
-version = "0.0.1"
-source = "git+https://github.com/rust-lang/time#d6219df8537e74fa87eeb7d372681c276dc5f9ff"
+version = "0.0.2"
+source = "git+https://github.com/rust-lang/time.git#b58210c93a44d7b83a1a9b68b462f5a7fa1942f3"
 dependencies = [
  "gcc 0.0.1 (git+https://github.com/alexcrichton/gcc-rs)",
 ]
@@ -199,10 +203,15 @@ dependencies = [
 [[package]]
 name = "url"
 version = "0.1.0"
-source = "git+https://github.com/nickel-org/rust-url.git#8a61b7654ab5378b488225a1d8a9cbbbcbd38894"
+source = "git+https://github.com/nickel-org/rust-url.git#f5fdbe5741ff75d87ef05b468097432c012c3e6e"
 dependencies = [
- "encoding 0.2.0 (git+https://github.com/lifthrasiir/rust-encoding)",
+ "encoding 0.2.1 (git+https://github.com/lifthrasiir/rust-encoding)",
 ]
+
+[[package]]
+name = "uuid"
+version = "0.0.2"
+source = "git+https://github.com/rust-lang/uuid#410aa2f519a66431214282c1d74d9f95316fb0ff"
 
 [[package]]
 name = "xxhash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Steve Klabnik <steve@steveklabnik.com>", "Josef Pospíšil <josef.po
 
 [dependencies.nickel]
 
-git = "https://github.com/iterion/nickel.rs.git"
+git = "https://github.com/nickel-org/nickel.rs.git"
 
 [dependencies.postgres]
 
@@ -15,3 +15,7 @@ git = "https://github.com/sfackler/rust-postgres.git"
 [dependencies.r2d2_postgres]
 
 git = "https://github.com/sfackler/r2d2-postgres.git"
+
+[dependencies.time]
+
+git = "https://github.com/rust-lang/time.git"

--- a/src/bin/create_databases.rs
+++ b/src/bin/create_databases.rs
@@ -1,15 +1,15 @@
 extern crate postgres;
 
-use postgres::{Connection, NoSsl};
+use postgres::{Connection, SslMode};
 
 fn main() {
     let conn = Connection::connect("postgres://rustmvc@localhost",
-                                           &NoSsl).unwrap();
+                                           &SslMode::None).unwrap();
 
     conn.execute("CREATE TABLE todos (
                     id              SERIAL PRIMARY KEY,
                     title           VARCHAR NOT NULL,
                     is_completed    BOOLEAN NOT NULL
-                  )", []).unwrap();
+                  )", &[]).unwrap();
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use nickel::{
 
 use postgres::{
     Connection,
-    NoSsl
+    SslMode
 };
 
 use r2d2_postgres::PostgresPoolManager;
@@ -56,7 +56,7 @@ impl ConnectionPool {
     fn new() -> ConnectionPool {
         // this isn't super secure but it's also just a toy so whatever
         ConnectionPool {
-            pool: PostgresPoolManager::new("postgres://rustmvc@localhost", NoSsl),
+            pool: PostgresPoolManager::new("postgres://rustmvc@localhost", SslMode::None),
         }
     }
 }
@@ -94,7 +94,7 @@ fn get_todos(req: &Request, _: &mut Response) -> Json {
     let conn = opt_conn.unwrap();
 
     let stmt = conn.prepare("SELECT id, title, is_completed FROM todos").unwrap();
-    let results = stmt.query([]).unwrap().map(|row| {
+    let results = stmt.query(&[]).unwrap().map(|row| {
         Todo {
             id: row.get(0u),
             title: row.get(1u),


### PR DESCRIPTION
It seems like a few rust changes broke `get_todos`. I had to point to my own fork of `nickel.rs` while I'm waiting for nickel-org/rust-http#2 to be merged. I'm happy to wait until that is merged and pointing back to mainline `nickel.rs` before merging this.

I implemented `ToJson` on `Todo` instead of on `Vec<Todo>` primarily because we get `Vec<Todo>.to_json()` for free when doing so. Also, it seems like it might be better to build a layer on top of the core json serialization stuff to get our output a little more `JSON API`-ish. I'm not sure if this is the direction we should go, so input here is greatly appreciated.
